### PR TITLE
fix loadingview UIActivityIndicatorView space

### DIFF
--- a/GitHubApp/Screens/Components/LoadingView.swift
+++ b/GitHubApp/Screens/Components/LoadingView.swift
@@ -7,7 +7,7 @@ final class LoadingView: UIView {
         let view = UIStackView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.axis = .vertical
-        view.spacing = 166
+        view.spacing = 16
         return view
     }()
     


### PR DESCRIPTION
 
## Describe your changes 

- Corrigindo o espaçamento entre a UILabel e o UIActivityIndicatorView dentro da UIStackView
 
## Checklist before requesting a review

Put an "X" in the boxes that apply.

- [x] I have performed a self-review of my code
- [] New and existing unit tests pass locally with my changes
- [x] Does not contain commented code
 
## Screenshots (if appropriate)

| Screenshot 1 | Screenshot 2 |
| ------ | ------ |
| Place here | Place here |
